### PR TITLE
ignoring isograder log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+isograder.log


### PR DESCRIPTION
The log produced by the tool should be automatically ignored by the repo.
